### PR TITLE
Builder: Add ToFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,17 +213,13 @@ err := requests.
 It depends on exactly what you need in terms of file atomicity and buffering, but this will work for most cases:
 
 ```go
-	f, err := os.Create("myfile.txt")
-	if err != nil {
-		// handle
-	}
-	defer f.Close()
-
-	err = requests.
+	err := requests.
 		URL("http://example.com").
-		ToWriter(f).
+		ToFile("myfile.txt").
 		Fetch(context.Background())
 ```
+
+For more advanced use case, use `ToWriter`. 
 
 ### How do I save a response to a string?
 

--- a/builder.go
+++ b/builder.go
@@ -269,6 +269,13 @@ func (rb *Builder) ToWriter(w io.Writer) *Builder {
 	return rb.Handle(ToWriter(w))
 }
 
+// ToFile sets the Builder to write the response body to given file. The file
+// and its parent directories are automatically created with default permission.
+// For more advanced use case, use ToWriter.
+func (rb *Builder) ToFile(name string) *Builder {
+	return rb.Handle(ToFile(name))
+}
+
 // Config allows Builder to be extended by functions that set several options at once.
 func (rb *Builder) Config(cfg Config) *Builder {
 	cfg(rb)

--- a/builder_example_test.go
+++ b/builder_example_test.go
@@ -118,6 +118,29 @@ func ExampleBuilder_ToWriter() {
 	// file is 1256 bytes
 }
 
+func ExampleBuilder_ToFile() {
+	d, err := os.MkdirTemp("", "to_file_*")
+	if err != nil {
+		log.Fatal(err)
+	}
+	tmpFile := filepath.Join(d, "parent_dir", "example.txt")
+	defer os.RemoveAll(d) // clean up
+	err = requests.URL("http://example.com").
+		ToFile(tmpFile).
+		Fetch(context.Background())
+	if err != nil {
+		log.Fatal(err)
+	}
+	stat, err := os.Stat(tmpFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("file is %d bytes\n", stat.Size())
+
+	// Output:
+	// file is 1256 bytes
+}
+
 type placeholder struct {
 	ID     int    `json:"id,omitempty"`
 	Title  string `json:"title"`

--- a/handler.go
+++ b/handler.go
@@ -121,6 +121,8 @@ func ToFile(name string) ResponseHandler {
 			return err
 		}
 		defer f.Close()
-		return ToWriter(f)(res)
+
+		_, err = io.Copy(f, res.Body)
+		return err
 	}
 }

--- a/handler.go
+++ b/handler.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"golang.org/x/net/html"
@@ -104,4 +106,21 @@ func ToWriter(w io.Writer) ResponseHandler {
 
 		return err
 	})
+}
+
+// ToFile writes the response body to file.
+func ToFile(name string) ResponseHandler {
+	return func(res *http.Response) error {
+		err := os.MkdirAll(filepath.Dir(name), 0777)
+		if err != nil {
+			return err
+		}
+
+		f, err := os.Create(name)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		return ToWriter(f)(res)
+	}
 }

--- a/handler.go
+++ b/handler.go
@@ -111,10 +111,7 @@ func ToWriter(w io.Writer) ResponseHandler {
 // ToFile writes the response body to file.
 func ToFile(name string) ResponseHandler {
 	return func(res *http.Response) error {
-		err := os.MkdirAll(filepath.Dir(name), 0777)
-		if err != nil {
-			return err
-		}
+		_ = os.MkdirAll(filepath.Dir(name), 0777)
 
 		f, err := os.Create(name)
 		if err != nil {

--- a/handler_test.go
+++ b/handler_test.go
@@ -1,0 +1,31 @@
+package requests_test
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/carlmjohnson/requests"
+)
+
+func BenchmarkBuilder_ToFile(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		d, err := os.MkdirTemp("", "to_file_*")
+		if err != nil {
+			b.Fatal(err)
+		}
+		tmpFile := filepath.Join(d, "100mb.test")
+		b.Cleanup(func() {
+			os.RemoveAll(d)
+		})
+		err = requests.URL("http://speedtest-sgp1.digitalocean.com/100mb.test").
+			Client(&http.Client{Transport: http.DefaultTransport}).
+			ToFile(tmpFile).
+			Fetch(context.Background())
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
that writes the response body to a file. The file and its parent directories are automatilly created with default permissions.

Follow up the discussion in https://lobste.rs/s/ocjhfm/why_i_wrote_my_own_go_http_client#c_ijhq8c.