### PR TITLE
Add support for clients with X509 certificates or X509 proxies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/carlmjohnson/requests
 go 1.17
 
 require golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f
+
+require github.com/vkuznet/x509proxy v0.0.0-20210801171832-e47b94db99b6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/vkuznet/x509proxy v0.0.0-20210801171832-e47b94db99b6 h1:Y5LCuH9nfTZ6srI5NaoKKbcDb01zqTHw8678++4fw0c=
+github.com/vkuznet/x509proxy v0.0.0-20210801171832-e47b94db99b6/go.mod h1:gfEPE3azFe+K/nMLezta3+kTiumttEYDawGAE72IYfM=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f h1:OfiFi4JbukWwe3lzw+xunroH1mnC1e2Gy5cxNJApiSY=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/x509client.go
+++ b/x509client.go
@@ -1,0 +1,116 @@
+package requests
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+
+	"github.com/vkuznet/x509proxy"
+)
+
+// X509HttpClient represents Http client with full support for X509
+// (proxy) certificates.
+
+// client X509 certificates
+func tlsCerts(key, cert string) ([]tls.Certificate, error) {
+	uproxy := os.Getenv("X509_USER_PROXY")
+	uckey := os.Getenv("X509_USER_KEY")
+	ucert := os.Getenv("X509_USER_CERT")
+	if key != "" {
+		uckey = key
+	}
+	if cert != "" {
+		ucert = cert
+	}
+
+	// check if /tmp/x509up_u$UID exists, if so setup X509_USER_PROXY env
+	u, err := user.Current()
+	if err == nil {
+		fname := fmt.Sprintf("/tmp/x509up_u%s", u.Uid)
+		if _, err := os.Stat(fname); err == nil {
+			uproxy = fname
+		}
+	}
+
+	if uproxy == "" && uckey == "" { // user doesn't have neither proxy or user certs
+		return nil, nil
+	}
+	if uproxy != "" {
+		// use local implementation of LoadX409KeyPair instead of tls one
+		x509cert, err := x509proxy.LoadX509Proxy(uproxy)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse X509 proxy: %v", err)
+		}
+		certs := []tls.Certificate{x509cert}
+		return certs, nil
+	}
+	x509cert, err := tls.LoadX509KeyPair(ucert, uckey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse user X509 certificate: %v", err)
+	}
+	certs := []tls.Certificate{x509cert}
+	return certs, nil
+}
+
+// X509HttpClient is HTTP client for urlfetch server
+func X509HttpClient(key, cert, caPath string, skipVerify bool, verbose bool) *http.Client {
+	var certs []tls.Certificate
+	var err error
+	// get X509 certs
+	certs, err = tlsCerts(key, cert)
+	if err != nil {
+		log.Fatal("ERROR ", err.Error())
+	}
+	if verbose {
+		fmt.Printf("read %d certificates\n", len(certs))
+	}
+	if len(certs) == 0 {
+		return &http.Client{}
+	}
+	var tr *http.Transport
+	if caPath != "" {
+		rootCAs := x509.NewCertPool()
+		files, err := ioutil.ReadDir(caPath)
+		if err != nil {
+			log.Fatalf("Unable to list files in '%s', error: %v\n", caPath, err)
+		}
+		for _, finfo := range files {
+			fname := fmt.Sprintf("%s/%s", caPath, finfo.Name())
+			caCert, err := os.ReadFile(filepath.Clean(fname))
+			if err != nil {
+				log.Printf("Unable to read %s\n", fname)
+			}
+			if ok := rootCAs.AppendCertsFromPEM(caCert); !ok {
+				if strings.HasSuffix(fname, "pem") {
+					log.Printf("invalid PEM format while importing trust-chain: %q", fname)
+				}
+			}
+			if verbose {
+				fmt.Printf("read %s\n", fname)
+			}
+		}
+		tr = &http.Transport{
+			TLSClientConfig: &tls.Config{
+				Certificates:       certs,
+				RootCAs:            rootCAs,
+				InsecureSkipVerify: skipVerify},
+		}
+	} else {
+		tr = &http.Transport{
+			TLSClientConfig: &tls.Config{
+				Certificates:       certs,
+				InsecureSkipVerify: skipVerify},
+		}
+	}
+	if verbose {
+		fmt.Printf("HTTP transport %+v\n", tr)
+	}
+	return &http.Client{Transport: tr}
+}


### PR DESCRIPTION
At CERN we need [X509](https://www.wikiwand.com/en/X.509) support in our clients (see [X509 certificates](https://www.ssl.com/faqs/what-is-an-x-509-certificate/)). As such I find that it can be easily added to your project and significantly simplify writing such clients. On a client side it can be done as following:
```
    var s string
    key := "/path/userkey.pem"
    cert := "/path/usercert.pem"
    caPath := "/etc/grid-security/certificates"
    skipVerify := true
    verbose := false
    ctx := context.TODO()
    client := requests.X509HttpClient(key, cert, caPath, skipVerify, verbose)
    err := requests.
        URL(url).
        Client(client).
        ToString(&s).
        Fetch(ctx)
```
This PR provides codebase to support HTTP clients which can be initialized either with [x509 certificates](https://www.ssl.com/faqs/what-is-an-x-509-certificate/) or [x509 proxy](https://www.ietf.org/rfc/rfc3820.txt). Of course, it is optional and I will understand if you will not accept it, e.g. http x509 client can be put into separate packages. I only find that it may be useful to enrich requests library to specific kind of clients and reduce overhead for end-users who may choose to use your library. Of course, I can provide additional example test files if you'll be interested in this PR.