### PR TITLE
main - custom json serializers

### DIFF
--- a/body.go
+++ b/body.go
@@ -2,7 +2,6 @@ package requests
 
 import (
 	"bytes"
-	"encoding/json"
 	"io"
 	"net/url"
 	"os"
@@ -47,7 +46,7 @@ func BodyBytes(b []byte) BodyGetter {
 // BodyJSON is a BodyGetter that marshals a JSON object.
 func BodyJSON(v any) BodyGetter {
 	return func() (io.ReadCloser, error) {
-		b, err := json.Marshal(v)
+		b, err := jsonMarshal(v)
 		if err != nil {
 			return nil, err
 		}

--- a/handler.go
+++ b/handler.go
@@ -3,7 +3,6 @@ package requests
 import (
 	"bufio"
 	"bytes"
-	"encoding/json"
 	"io"
 	"net/http"
 	"os"
@@ -46,7 +45,7 @@ func ToJSON(v any) ResponseHandler {
 		if err != nil {
 			return err
 		}
-		if err = json.Unmarshal(data, v); err != nil {
+		if err = jsonUnmarshal(data, v); err != nil {
 			return err
 		}
 		return nil

--- a/json.go
+++ b/json.go
@@ -20,6 +20,8 @@ func SetJSONMarshaller(j jsonMarshaller) {
 	jsonMarshal = j
 }
 
+// SetJSONSerializers is a function to set global json.Marshal/json.Unmarshal function
+// For faster serialization/deserialization you can use functions from, for instance, https://github.com/goccy/go-json
 func SetJSONSerializers(marshaller jsonMarshaller, unmarshaller jsonUnmarshaller) {
 	jsonMarshal = marshaller
 	jsonUnmarshal = unmarshaller

--- a/json.go
+++ b/json.go
@@ -1,0 +1,26 @@
+package requests
+
+import (
+	"encoding/json"
+)
+
+type jsonMarshaller = func(v any) ([]byte, error)
+type jsonUnmarshaller = func(data []byte, v any) error
+
+var (
+	jsonMarshal   = json.Marshal
+	jsonUnmarshal = json.Unmarshal
+)
+
+func SetJSONUnmarshaller(j jsonUnmarshaller) {
+	jsonUnmarshal = j
+}
+
+func SetJSONMarshaller(j jsonMarshaller) {
+	jsonMarshal = j
+}
+
+func SetJSONSerializers(marshaller jsonMarshaller, unmarshaller jsonUnmarshaller) {
+	jsonMarshal = marshaller
+	jsonUnmarshal = unmarshaller
+}


### PR DESCRIPTION
Hi, I came up with a way not to drag new dependencies, while took goccy/go-json in projects, were we are using your library. Developer could use `SetJSONSerializers(gojson.Marshal, gojson.Unmarshal)` in his main() function and enjoy faster json serialization/deserialization